### PR TITLE
Enable auto-saving of note titles when changed

### DIFF
--- a/src/NewNote/Newnote.js
+++ b/src/NewNote/Newnote.js
@@ -57,7 +57,6 @@ const Newnote = (props) => {
       setbtnArr([...arr]);
     }
     
-    
     localStorage.setItem("data", JSON.stringify([...btnArr]));
   }
 
@@ -117,7 +116,7 @@ const Newnote = (props) => {
           {btnArr.map((btn, idx) => {
             return (
               <div className="btns" key={`unique_${idx}_${Math.random() * 10}`}>
-                <p className="Btn" onKeyDown={(e)=>chngeData(e)} contentEditable="true" onClick={() => { showClickedNote(idx); }}>
+                <p className="Btn" onKeyDown={(e)=>chngeData(e)} onBlur={(e) => chngeData(e)} contentEditable="true" onClick={() => { showClickedNote(idx); }}>
                   {btn.btn}
                 </p>
                 {/* <button >Delete</button> */}


### PR DESCRIPTION
#1 

### What do you want to achieve?
This pull request aims to implement an auto-saving feature for note titles in the Notepad application. The main purpose is to enhance user experience by ensuring that the title input is saved automatically when a user navigates between notes, thus preventing data loss.

### PR Checklist
 I have tested it locally and all functionalities are working fine.
### How was the code tested?
The following steps were taken to test the code:

Opened the Notepad application and created multiple notes.
Edited the title of a note without pressing enter and navigated to another note.
Verified that the entire title was saved correctly, including the last character.
Checked for any console errors or unexpected behavior during the testing process.
### Screenshot:
![note-app-fixing](https://github.com/user-attachments/assets/66129d63-623a-4dd5-8a7d-ae5d5918345b)
![note-app-fixed](https://github.com/user-attachments/assets/5fc3ca5a-0b26-4a2a-b7f9-0372861a591d)


### Root Cause :  
This feature was developed in response to a previously identified issue where the last character of a note title was not being saved when a user navigated away from the note without pressing enter. The root cause was traced to state management and event handling, which have now been addressed in this update.